### PR TITLE
Callbcaks as func pointer

### DIFF
--- a/rclobjc/include/rclobjc/ROSClient.h
+++ b/rclobjc/include/rclobjc/ROSClient.h
@@ -15,16 +15,16 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (*FunctionPointer)(id);
+typedef void (*ROSServiceCallbackType)(NSObject *, NSObject *, NSObject *);
 
 @interface FunctionPointerContainer:NSObject {
-   FunctionPointer funtionPointer;
+   ROSServiceCallbackType funtionPointer;
 }
 
-- (instancetype)initWithArguments: (FunctionPointer)init_funtionPointer;
-- (FunctionPointer)getFunctionPointer;
+- (instancetype)initWithArguments: (ROSServiceCallbackType)init_funtionPointer;
+- (ROSServiceCallbackType)getFunctionPointer;
 
-@property(readonly) FunctionPointer funtionPointer;
+@property(readonly) ROSServiceCallbackType funtionPointer;
 
 @end
 
@@ -43,7 +43,7 @@ typedef void (*FunctionPointer)(id);
                      clientHandle:(Class)
                       serviceType:(NSString *)serviceName;
 
-- (void)sendRequest:(id)request:(void (*)(id))callback;
+- (void)sendRequest:(id)request:(ROSServiceCallbackType)callback;
 
 - (void)handleResponse:(int64_t)sequenceNumber:(id)response;
 

--- a/rclobjc/include/rclobjc/ROSClient.h
+++ b/rclobjc/include/rclobjc/ROSClient.h
@@ -15,6 +15,19 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (*FunctionPointer)(id);
+
+@interface FunctionPointerContainer:NSObject {
+   FunctionPointer funtionPointer;
+}
+
+- (instancetype)initWithArguments: (FunctionPointer)init_funtionPointer;
+- (FunctionPointer)getFunctionPointer;
+
+@property(readonly) FunctionPointer funtionPointer;
+
+@end
+
 @interface ROSClient<MessageType> : NSObject {
   intptr_t nodeHandle;
   intptr_t clientHandle;
@@ -22,7 +35,7 @@
   NSString *serviceName;
   Class requestType;
   Class responseType;
-  NSMutableDictionary<NSNumber *, void (^)(id)> *pendingRequests;
+  NSMutableDictionary<NSNumber *, FunctionPointerContainer *> *pendingRequests;
 }
 
 - (instancetype)initWithArguments:(intptr_t)
@@ -30,7 +43,7 @@
                      clientHandle:(Class)
                       serviceType:(NSString *)serviceName;
 
-- (void)sendRequest:(id)request:(void (^)(id))callback;
+- (void)sendRequest:(id)request:(void (*)(id))callback;
 
 - (void)handleResponse:(int64_t)sequenceNumber:(id)response;
 

--- a/rclobjc/include/rclobjc/ROSClient.h
+++ b/rclobjc/include/rclobjc/ROSClient.h
@@ -14,7 +14,7 @@
  */
 
 #import <Foundation/Foundation.h>
-
+z
 @interface ROSClient<MessageType> : NSObject {
   intptr_t nodeHandle;
   intptr_t clientHandle;
@@ -22,7 +22,7 @@
   NSString *serviceName;
   Class requestType;
   Class responseType;
-  NSMutableDictionary<NSNumber *, void (^)(id)> *pendingRequests;
+  NSMutableDictionary<NSNumber *, void (*)(id)> *pendingRequests;
 }
 
 - (instancetype)initWithArguments:(intptr_t)

--- a/rclobjc/include/rclobjc/ROSNode.h
+++ b/rclobjc/include/rclobjc/ROSNode.h
@@ -33,11 +33,11 @@
 
 - (ROSSubscription *)createSubscriptionWithCallback:(Class)
                                         messageType:(NSString *)
-                                              topic:(void (*)(id))callback;
+                                              topic:(ROSSubscriptionCallbackType)callback;
 
 - (ROSService *)createServiceWithCallback:(Class)
                               serviceType:(NSString *)
-                              serviceName:(void (*)(id, id, id))callback;
+                              serviceName:(ROSServiceCallbackType)callback;
 
 - (ROSClient *)createClient:(Class)serviceType:(NSString *)serviceName;
 

--- a/rclobjc/include/rclobjc/ROSNode.h
+++ b/rclobjc/include/rclobjc/ROSNode.h
@@ -33,11 +33,11 @@
 
 - (ROSSubscription *)createSubscriptionWithCallback:(Class)
                                         messageType:(NSString *)
-                                              topic:(void (^)(id))callback;
+                                              topic:(void (*)(id))callback;
 
 - (ROSService *)createServiceWithCallback:(Class)
                               serviceType:(NSString *)
-                              serviceName:(void (^)(id, id, id))callback;
+                              serviceName:(void (*)(id, id, id))callback;
 
 - (ROSClient *)createClient:(Class)serviceType:(NSString *)serviceName;
 

--- a/rclobjc/include/rclobjc/ROSService.h
+++ b/rclobjc/include/rclobjc/ROSService.h
@@ -20,20 +20,20 @@
   intptr_t serviceHandle;
   Class serviceType;
   NSString *serviceName;
-  void (^callback)(NSObject *, NSObject *, NSObject *);
+  void (*callback)(NSObject *, NSObject *, NSObject *);
 }
 
 - (instancetype)initWithArguments:(intptr_t)
                        nodeHandle:(intptr_t)
                     serviceHandle:(Class)
                       serviceType:(NSString *)
-                      serviceName:(void (^)(NSObject *, NSObject *,
+                      serviceName:(void (*)(NSObject *, NSObject *,
                                             NSObject *))callback;
 
 @property(readonly) intptr_t nodeHandle;
 @property(readonly) intptr_t serviceHandle;
 @property(readonly) Class serviceType;
 @property(readonly) NSString *serviceName;
-@property(readonly) void (^callback)(NSObject *, NSObject *, NSObject *);
+@property(readonly) void (*callback)(NSObject *, NSObject *, NSObject *);
 
 @end

--- a/rclobjc/include/rclobjc/ROSService.h
+++ b/rclobjc/include/rclobjc/ROSService.h
@@ -15,25 +15,26 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (*ROSServiceCallbackType)(NSObject *, NSObject *, NSObject *);
+
 @interface ROSService<MessageType> : NSObject {
   intptr_t nodeHandle;
   intptr_t serviceHandle;
   Class serviceType;
   NSString *serviceName;
-  void (*callback)(NSObject *, NSObject *, NSObject *);
+  ROSServiceCallbackType callback;
 }
 
 - (instancetype)initWithArguments:(intptr_t)
                        nodeHandle:(intptr_t)
                     serviceHandle:(Class)
                       serviceType:(NSString *)
-                      serviceName:(void (*)(NSObject *, NSObject *,
-                                            NSObject *))callback;
+                      serviceName:(ROSServiceCallbackType)callback;
 
 @property(readonly) intptr_t nodeHandle;
 @property(readonly) intptr_t serviceHandle;
 @property(readonly) Class serviceType;
 @property(readonly) NSString *serviceName;
-@property(readonly) void (*callback)(NSObject *, NSObject *, NSObject *);
+@property(readonly) ROSServiceCallbackType callback;
 
 @end

--- a/rclobjc/include/rclobjc/ROSSubscription.h
+++ b/rclobjc/include/rclobjc/ROSSubscription.h
@@ -19,20 +19,20 @@
   intptr_t nodeHandle;
   intptr_t subscriptionHandle;
   NSString *topic;
-  void (^callback)(NSObject *);
+  void (*callback)(NSObject *);
   Class messageType;
 }
 
-- (instancetype)initWithArguments:(intptr_t)
+- (instancetype)initWithArguments:(intptr_t) foo
                        nodeHandle:(intptr_t)
                subscriptionHandle:(NSString *)
                             topic:(Class)
-                      messageType:(void (^)(NSObject *))callback;
+                      messageType:(void (*)(NSObject *))callback;
 
 @property(readonly) intptr_t nodeHandle;
 @property(readonly) intptr_t subscriptionHandle;
 @property(readonly) NSString *topic;
-@property(readonly) void (^callback)(NSObject *);
+@property(readonly) void (*callback)(NSObject *);
 @property(readonly) Class messageType;
 
 @end

--- a/rclobjc/include/rclobjc/ROSSubscription.h
+++ b/rclobjc/include/rclobjc/ROSSubscription.h
@@ -15,11 +15,13 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (*ROSSubscriptionCallbackType)(NSObject *);
+
 @interface ROSSubscription <MessageType> : NSObject {
   intptr_t nodeHandle;
   intptr_t subscriptionHandle;
   NSString *topic;
-  void (*callback)(NSObject *);
+  ROSSubscriptionCallbackType callback;
   Class messageType;
 }
 
@@ -27,12 +29,12 @@
                        nodeHandle:(intptr_t)
                subscriptionHandle:(NSString *)
                             topic:(Class)
-                      messageType:(void (*)(NSObject *))callback;
+                      messageType:(ROSSubscriptionCallbackType)callback;
 
 @property(readonly) intptr_t nodeHandle;
 @property(readonly) intptr_t subscriptionHandle;
 @property(readonly) NSString *topic;
-@property(readonly) void (*callback)(NSObject *);
+@property(readonly) ROSSubscriptionCallbackType callback;
 @property(readonly) Class messageType;
 
 @end

--- a/rclobjc/include/rclobjc/ROSSubscription.h
+++ b/rclobjc/include/rclobjc/ROSSubscription.h
@@ -19,7 +19,7 @@
   intptr_t nodeHandle;
   intptr_t subscriptionHandle;
   NSString *topic;
-  void (^callback)(NSObject *);
+  void (*callback)(NSObject *);
   Class messageType;
 }
 
@@ -27,12 +27,12 @@
                        nodeHandle:(intptr_t)
                subscriptionHandle:(NSString *)
                             topic:(Class)
-                      messageType:(void (^)(NSObject *))callback;
+                      messageType:(void (*)(NSObject *))callback;
 
 @property(readonly) intptr_t nodeHandle;
 @property(readonly) intptr_t subscriptionHandle;
 @property(readonly) NSString *topic;
-@property(readonly) void (^callback)(NSObject *);
+@property(readonly) void (*callback)(NSObject *);
 @property(readonly) Class messageType;
 
 @end

--- a/rclobjc/src/ROSClient.m
+++ b/rclobjc/src/ROSClient.m
@@ -22,7 +22,7 @@
 
 @interface FunctionPointerContainer ()
 
-@property(assign) FunctionPointer funtionPointer;
+@property(assign) ROSServiceCallbackType funtionPointer;
 
 @end
 
@@ -30,12 +30,12 @@
 
 @synthesize funtionPointer;
 
-- (instancetype)initWithArguments: (FunctionPointer)init_funtionPointer {
+- (instancetype)initWithArguments: (ROSServiceCallbackType)init_funtionPointer {
     self.funtionPointer = init_funtionPointer;
     return self;
 }
 
-- (FunctionPointer)getFunctionPointer {
+- (ROSServiceCallbackType)getFunctionPointer {
     return self.funtionPointer;
 }
 @end
@@ -82,7 +82,7 @@
   return self;
 }
 
-- (void)sendRequest:(id)request:(void (*)(id))callback {
+- (void)sendRequest:(id)request:(ROSServiceCallbackType)callback {
   rcl_client_t *client = (rcl_client_t *)self.clientHandle;
 
   typedef void *(*convert_from_objc_signature)(NSObject *);
@@ -109,7 +109,7 @@
 - (void)handleResponse:(int64_t)sequenceNumber:(id)response {
   NSNumber *nsseq = [NSNumber numberWithInteger:sequenceNumber];
 
-  void (*callback)(id) = [[self.pendingRequests objectForKey:nsseq] getFunctionPointer];
+  void (*callback)(NSObject *) = [[self.pendingRequests objectForKey:nsseq] getFunctionPointer];
   [self.pendingRequests removeObjectForKey:nsseq];
   callback(response);
 }

--- a/rclobjc/src/ROSClient.m
+++ b/rclobjc/src/ROSClient.m
@@ -29,7 +29,7 @@
 @property(assign) Class requestType;
 @property(assign) Class responseType;
 @property(assign)
-    NSMutableDictionary<NSNumber *, void (^)(id)> *pendingRequests;
+    NSMutableDictionary<NSNumber *, void (*)(id)> *pendingRequests;
 
 @end
 
@@ -60,7 +60,7 @@
   return self;
 }
 
-- (void)sendRequest:(id)request:(void (^)(id))callback {
+- (void)sendRequest:(id)request:(void (*)(id))callback {
   rcl_client_t *client = (rcl_client_t *)self.clientHandle;
 
   typedef void *(*convert_from_objc_signature)(NSObject *);
@@ -84,8 +84,8 @@
 
 - (void)handleResponse:(int64_t)sequenceNumber:(id)response {
   NSNumber *nsseq = [NSNumber numberWithInteger:sequenceNumber];
-  // void(^callback)(id) = self.pendingRequests[nsseq];
-  void (^callback)(id) = [self.pendingRequests objectForKey:nsseq];
+  // void(*callback)(id) = self.pendingRequests[nsseq];
+  void (*callback)(id) = [self.pendingRequests objectForKey:nsseq];
   [self.pendingRequests removeObjectForKey:nsseq];
   callback(response);
 }

--- a/rclobjc/src/ROSNode.m
+++ b/rclobjc/src/ROSNode.m
@@ -173,7 +173,7 @@
 
 - (ROSSubscription *)createSubscriptionWithCallback:(Class)
                                         messageType:(NSString *)
-                                              topic:(void (^)(id))callback {
+                                              topic:(void (*)(id))callback {
   intptr_t subscriptionHandle =
       [ROSNode createSubscriptionHandle:self.nodeHandle:messageType:topic];
   ROSSubscription *subscription = [[ROSSubscription alloc] initWithArguments :self.nodeHandle :subscriptionHandle :topic :messageType :callback];
@@ -183,7 +183,7 @@
 
 - (ROSService *)createServiceWithCallback:(Class)
                               serviceType:(NSString *)
-                              serviceName:(void (^)(id, id, id))callback {
+                              serviceName:(void (*)(id, id, id))callback {
   intptr_t serviceHandle =
       [ROSNode createServiceHandle:self.nodeHandle:serviceType:serviceName];
   ROSService *service = [[ROSService alloc] initWithArguments :self.nodeHandle :serviceHandle :serviceType :serviceName :callback];

--- a/rclobjc/src/ROSNode.m
+++ b/rclobjc/src/ROSNode.m
@@ -173,7 +173,7 @@
 
 - (ROSSubscription *)createSubscriptionWithCallback:(Class)
                                         messageType:(NSString *)
-                                              topic:(void (*)(id))callback {
+                                              topic:(ROSSubscriptionCallbackType)callback {
   intptr_t subscriptionHandle =
       [ROSNode createSubscriptionHandle:self.nodeHandle:messageType:topic];
   ROSSubscription *subscription = [[ROSSubscription alloc] initWithArguments :self.nodeHandle :subscriptionHandle :topic :messageType :callback];
@@ -183,7 +183,7 @@
 
 - (ROSService *)createServiceWithCallback:(Class)
                               serviceType:(NSString *)
-                              serviceName:(void (*)(id, id, id))callback {
+                              serviceName:(ROSServiceCallbackType)callback {
   intptr_t serviceHandle =
       [ROSNode createServiceHandle:self.nodeHandle:serviceType:serviceName];
   ROSService *service = [[ROSService alloc] initWithArguments :self.nodeHandle :serviceHandle :serviceType :serviceName :callback];

--- a/rclobjc/src/ROSService.m
+++ b/rclobjc/src/ROSService.m
@@ -26,7 +26,7 @@
 @property(assign) intptr_t serviceHandle;
 @property(assign) Class serviceType;
 @property(assign) NSString *serviceName;
-@property(assign) void (^callback)(NSObject *, NSObject *, NSObject *);
+@property(assign) void (*callback)(NSObject *, NSObject *, NSObject *);
 
 @end
 
@@ -42,7 +42,7 @@
                        nodeHandle:(intptr_t)
                     serviceHandle:(Class)
                       serviceType:(NSString *)
-                      serviceName:(void (^)(NSObject *, NSObject *,
+                      serviceName:(void (*)(NSObject *, NSObject *,
                                             NSObject *))callback {
   self.nodeHandle = nodeHandle;
   self.serviceHandle = serviceHandle;

--- a/rclobjc/src/ROSService.m
+++ b/rclobjc/src/ROSService.m
@@ -26,7 +26,7 @@
 @property(assign) intptr_t serviceHandle;
 @property(assign) Class serviceType;
 @property(assign) NSString *serviceName;
-@property(assign) void (*callback)(NSObject *, NSObject *, NSObject *);
+@property(assign) ROSServiceCallbackType callback;
 
 @end
 
@@ -42,8 +42,7 @@
                        nodeHandle:(intptr_t)
                     serviceHandle:(Class)
                       serviceType:(NSString *)
-                      serviceName:(void (*)(NSObject *, NSObject *,
-                                            NSObject *))callback {
+                      serviceName:(ROSServiceCallbackType)callback {
   self.nodeHandle = nodeHandle;
   self.serviceHandle = serviceHandle;
   self.serviceType = serviceType;

--- a/rclobjc/src/ROSSubscription.m
+++ b/rclobjc/src/ROSSubscription.m
@@ -25,7 +25,7 @@
 @property(assign) intptr_t nodeHandle;
 @property(assign) intptr_t subscriptionHandle;
 @property(assign) NSString *topic;
-@property(assign) void (*callback)(NSObject *);
+@property(assign) ROSSubscriptionCallbackType callback;
 @property(assign) Class messageType;
 
 @end
@@ -42,7 +42,7 @@
                        nodeHandle:(intptr_t)
                subscriptionHandle:(NSString *)
                             topic:(Class)
-                      messageType:(void (*)(NSObject *))callback {
+                      messageType:(ROSSubscriptionCallbackType)callback {
   self.nodeHandle = nodeHandle;
   self.subscriptionHandle = subscriptionHandle;
   self.topic = topic;

--- a/rclobjc/src/ROSSubscription.m
+++ b/rclobjc/src/ROSSubscription.m
@@ -25,7 +25,7 @@
 @property(assign) intptr_t nodeHandle;
 @property(assign) intptr_t subscriptionHandle;
 @property(assign) NSString *topic;
-@property(assign) void (^callback)(NSObject *);
+@property(assign) void (*callback)(NSObject *);
 @property(assign) Class messageType;
 
 @end
@@ -42,7 +42,7 @@
                        nodeHandle:(intptr_t)
                subscriptionHandle:(NSString *)
                             topic:(Class)
-                      messageType:(void (^)(NSObject *))callback {
+                      messageType:(void (*)(NSObject *))callback {
   self.nodeHandle = nodeHandle;
   self.subscriptionHandle = subscriptionHandle;
   self.topic = topic;


### PR DESCRIPTION
Hi @esteve,

We have been developing in Swift, and we found that Blocks in Objective-c are not working with swift closures. We found that using function pointers instead of blocks solves the problem. 

This PR changes blocks to function pointers for callbacks.

Hope you find interesting ;)

Best
Paco 